### PR TITLE
Fix import in routes

### DIFF
--- a/src/components/AppRoutes.jsx
+++ b/src/components/AppRoutes.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 import { Router, browserHistory } from 'react-router';
-import routes from '../routes';
+import routes from '../Routes';
 import { store } from './Store';
 
 export default class AppRoutes extends React.Component {


### PR DESCRIPTION
Steps to reproduce:

```
$ yarn
$ yarn run dev
```

![routeserror](https://cloud.githubusercontent.com/assets/1252707/21347178/cc7b21fe-c6a7-11e6-84ce-d8382484179a.png)

May be you cannot reproduce this error if you are using OSX:

http://stackoverflow.com/questions/36131934/module-not-found-error-cannot-resolve-file-or-directory
https://www.npmjs.com/package/case-sensitive-paths-webpack-plugin